### PR TITLE
Correcting a typo in Biography entity

### DIFF
--- a/src/main/java/com/draag/services/model/President.java
+++ b/src/main/java/com/draag/services/model/President.java
@@ -157,7 +157,7 @@ public class President {
 		private String LieuDeDeces;
 		@Embedded("epouses")
 		private List<Epouse> epouses;
-		@Embedded("entants")
+		@Embedded("enfants")
 		private List<Enfant> enfants;
 		
 		


### PR DESCRIPTION
enfants resource was spelled wrongly as entants.